### PR TITLE
Add `ResourceAssociation` update operation

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-09-19T23:44:11Z"
+  build_date: "2024-09-23T21:53:56Z"
   build_hash: f8f98563404066ac3340db0a049d2e530e5c51cc
   go_version: go1.23.0
   version: v0.38.1
-api_directory_checksum: 0156ad977aa0dd2b311f1064cb8520b8d8a490c1
+api_directory_checksum: 40345cfd6c95d741d814c140367949d9e3e9b811
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: 63d687c51f31cd6876aa96904116ed9dc135f3b2
+  file_checksum: 5d827c8e56feffbd7dbf1b3cc0b37ffd943feee8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -8,6 +8,9 @@ ignore:
       - PermissionVersion
 resources:
   ResourceShare:
+    exceptions:
+      terminal_codes:
+        - MalformedArnException
     fields:
       PermissionARNs:
         references:
@@ -31,6 +34,9 @@ resources:
       sdk_file_end:
         template_path: hooks/resource_share/sdk_file_end.go.tpl
   Permission:
+    exceptions:
+      terminal_codes:
+        - InvalidParameterException
     hooks:
       sdk_read_one_post_set_output:
         template_path: hooks/permission/sdk_read_one_post_set_output.go.tpl

--- a/generator.yaml
+++ b/generator.yaml
@@ -8,6 +8,9 @@ ignore:
       - PermissionVersion
 resources:
   ResourceShare:
+    exceptions:
+      terminal_codes:
+        - MalformedArnException
     fields:
       PermissionARNs:
         references:
@@ -31,6 +34,9 @@ resources:
       sdk_file_end:
         template_path: hooks/resource_share/sdk_file_end.go.tpl
   Permission:
+    exceptions:
+      terminal_codes:
+        - InvalidParameterException
     hooks:
       sdk_read_one_post_set_output:
         template_path: hooks/permission/sdk_read_one_post_set_output.go.tpl

--- a/pkg/resource/permission/sdk.go
+++ b/pkg/resource/permission/sdk.go
@@ -482,6 +482,17 @@ func (rm *resourceManager) updateConditions(
 // and if the exception indicates that it is a Terminal exception
 // 'Terminal' exception are specified in generator configuration
 func (rm *resourceManager) terminalAWSError(err error) bool {
-	// No terminal_errors specified for this resource in generator config
-	return false
+	if err == nil {
+		return false
+	}
+	awsErr, ok := ackerr.AWSError(err)
+	if !ok {
+		return false
+	}
+	switch awsErr.Code() {
+	case "InvalidParameterException":
+		return true
+	default:
+		return false
+	}
 }

--- a/templates/hooks/resource_share/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/resource_share/sdk_read_many_post_set_output.go.tpl
@@ -1,4 +1,7 @@
-
 	if err = rm.getPermissionArns(ctx, &resource{ko}); err != nil {
+		return nil, err
+	}
+	
+	if err = rm.getResourceShareAssociations(ctx, &resource{ko}); err != nil {
 		return nil, err
 	}

--- a/templates/hooks/resource_share/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/resource_share/sdk_update_pre_build_request.go.tpl
@@ -10,6 +10,12 @@
 		}
 	}
 
-	if !delta.DifferentExcept("Spec.Tags", "Spec.PermissionARNs") {
+	if delta.DifferentAt("Spec.ResourceARNs") || delta.DifferentAt("Spec.Principals") || delta.DifferentAt("Spec.Sources") {
+		if err := rm.syncResources(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+
+	if !delta.DifferentExcept("Spec.Tags", "Spec.PermissionARNs", "Spec.ResourceARNs", "Spec.Principals", "Spec.Sources") {
 		return desired, nil
 	}

--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -17,11 +17,12 @@ for them.
 
 from dataclasses import dataclass
 from acktest.bootstrapping import Resources
+from acktest.bootstrapping.vpc import VPC
 from e2e import bootstrap_directory
 
 @dataclass
 class BootstrapResources(Resources):
-    pass
+    RamVPC: VPC
 
 _bootstrap_resources = None
 

--- a/test/e2e/ram_resource_share.py
+++ b/test/e2e/ram_resource_share.py
@@ -106,7 +106,7 @@ def get_resource_shares(resource_share_name):
         return None
 
 def list_associated_permissions(arn):
-    """Returns list of permissions for supplied ResourceShare name.
+    """Returns list of permissions for supplied ResourceShare arn.
 
     If no such ResourceShare exists, returns None
     """
@@ -121,3 +121,19 @@ def list_associated_permissions(arn):
             return None
     except c.OperationNotPermittedException:
         None
+
+def list_associated_resources(arn):
+    """Returns list of resourceArns for supplied ResourceShare arn.
+
+    If no such ResourceShare exists, returns None
+    """
+    c = boto3.client('ram')
+    try:
+        resp = c.get_resource_share_associations(
+            associationType='RESOURCE',
+            resourceShareArns=[arn],
+        )
+        if 'resourceShareAssociations' in resp and len(resp['resourceShareAssociations']) > 0:
+            return resp['resourceShareAssociations'][0]
+    except c.UnknownResourceException:
+        return None

--- a/test/e2e/resources/ram_resource_share_association.yaml
+++ b/test/e2e/resources/ram_resource_share_association.yaml
@@ -1,0 +1,11 @@
+apiVersion: ram.services.k8s.aws/v1alpha1
+kind: ResourceShare
+metadata:
+  name: $RESOURCE_SHARE_NAME
+spec:
+  name: $RESOURCE_SHARE_NAME
+  permissionARNs: 
+  - arn:aws:ram::aws:permission/AWSRAMDefaultPermissionSubnet
+  resourceARNs:
+  - $RESOURCE_ARN
+

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -15,6 +15,7 @@
 import logging
 
 from acktest.bootstrapping import Resources, BootstrapFailureException
+from acktest.bootstrapping.vpc import VPC
 
 from e2e import bootstrap_directory
 from e2e.bootstrap_resources import BootstrapResources
@@ -23,7 +24,7 @@ def service_bootstrap() -> Resources:
     logging.getLogger().setLevel(logging.INFO)
 
     resources = BootstrapResources(
-        # TODO: Add bootstrapping when you have defined the resources
+        RamVPC=VPC(name_prefix="ram-vpc", num_public_subnet=2)
     )
 
     try:


### PR DESCRIPTION
Description of changes:

This change allows the ram controller to associate
resourceArns, principals, and sources to a `resource share`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
