### PR TITLE
feat: Add Accept Mode to ResourceShare CRD for cross-account sharing

### DIFF
--- a/apis/v1alpha1/resource_share.go
+++ b/apis/v1alpha1/resource_share.go
@@ -23,22 +23,48 @@ import (
 // ResourceShareSpec defines the desired state of ResourceShare.
 //
 // Describes a resource share in RAM.
+//
+// This resource can operate in two modes:
+// 1. Create Mode (default): Creates a new resource share and shares resources with principals
+// 2. Accept Mode: Accepts an incoming resource share invitation from another account
+//
+// To use Accept Mode, set the acceptInvitation field with the ShareARN of the incoming share.
+// In Accept Mode, most other fields (name, principals, resourceARNs, etc.) are ignored.
 type ResourceShareSpec struct {
+
+	// AcceptInvitation configures this resource to accept an incoming share invitation
+	// instead of creating a new share. When set, the controller will:
+	// 1. Find the pending invitation for the specified ShareARN
+	// 2. Accept the invitation
+	// 3. Populate status with invitation details
+	//
+	// This is mutually exclusive with creating a new share. When acceptInvitation
+	// is set, fields like name, principals, and resourceARNs are ignored.
+	//
+	// Use this when you want to accept a share from another AWS account.
+	// +kubebuilder:validation:Optional
+	AcceptInvitation *AcceptInvitationSpec `json:"acceptInvitation,omitempty"`
 
 	// Specifies whether principals outside your organization in Organizations can
 	// be associated with a resource share. A value of true lets you share with
 	// individual Amazon Web Services accounts that are not in your organization.
 	// A value of false only has meaning if your account is a member of an Amazon
 	// Web Services Organization. The default value is true.
+	//
+	// This field is ignored when acceptInvitation is set.
 	AllowExternalPrincipals *bool `json:"allowExternalPrincipals,omitempty"`
 	// Specifies the name of the resource share.
-	// +kubebuilder:validation:Required
-	Name *string `json:"name"`
+	//
+	// This field is ignored when acceptInvitation is set.
+	// +kubebuilder:validation:Optional
+	Name *string `json:"name,omitempty"`
 	// Specifies the Amazon Resource Names (ARNs) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// of the RAM permission to associate with the resource share. If you do not
 	// specify an ARN for the permission, RAM automatically attaches the default
 	// version of the permission for each resource type. You can associate only
 	// one permission with each resource type included in the resource share.
+	//
+	// This field is ignored when acceptInvitation is set.
 	PermissionARNs []*string                                  `json:"permissionARNs,omitempty"`
 	PermissionRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"permissionRefs,omitempty"`
 	// Specifies a list of one or more principals to associate with the resource
@@ -61,17 +87,33 @@ type ResourceShareSpec struct {
 	// Not all resource types can be shared with IAM roles and users. For more information,
 	// see Sharing with IAM roles and users (https://docs.aws.amazon.com/ram/latest/userguide/permissions.html#permissions-rbp-supported-resource-types)
 	// in the Resource Access Manager User Guide.
+	//
+	// This field is ignored when acceptInvitation is set.
 	Principals []*string `json:"principals,omitempty"`
 	// Specifies a list of one or more ARNs of the resources to associate with the
 	// resource share.
+	//
+	// This field is ignored when acceptInvitation is set.
 	ResourceARNs []*string `json:"resourceARNs,omitempty"`
 	// Specifies from which source accounts the service principal has access to
 	// the resources in this resource share.
+	//
+	// This field is ignored when acceptInvitation is set.
 	Sources []*string `json:"sources,omitempty"`
 	// A list of one or more tag key and value pairs. The tag key must be present
 	// and not be an empty string. The tag value must be present but can be an empty
 	// string.
+	//
+	// This field is ignored when acceptInvitation is set.
 	Tags []*Tag `json:"tags,omitempty"`
+}
+
+// AcceptInvitationSpec defines the configuration for accepting an incoming share invitation
+type AcceptInvitationSpec struct {
+	// The Amazon Resource Name (ARN) of the resource share to accept.
+	// This should be the ARN of the share that was created by another account.
+	// +kubebuilder:validation:Required
+	ShareARN *string `json:"shareARN"`
 }
 
 // ResourceShareStatus defines the observed state of ResourceShare
@@ -124,6 +166,43 @@ type ResourceShareStatus struct {
 	// A message about the status of the resource share.
 	// +kubebuilder:validation:Optional
 	StatusMessage *string `json:"statusMessage,omitempty"`
+
+	// The following fields are populated only when spec.acceptInvitation is set
+	// (Accept Mode). They provide details about the accepted invitation.
+
+	// The ARN of the invitation that was accepted.
+	// Only populated in Accept Mode.
+	// +kubebuilder:validation:Optional
+	InvitationARN *string `json:"invitationARN,omitempty"`
+	// The current status of the invitation.
+	// Possible values: PENDING, ACCEPTED, REJECTED, EXPIRED
+	// Only populated in Accept Mode.
+	// +kubebuilder:validation:Optional
+	InvitationStatus *string `json:"invitationStatus,omitempty"`
+	// The ID of the AWS account that sent the invitation.
+	// Only populated in Accept Mode.
+	// +kubebuilder:validation:Optional
+	SenderAccountID *string `json:"senderAccountID,omitempty"`
+	// The ID of the AWS account that received the invitation.
+	// Only populated in Accept Mode.
+	// +kubebuilder:validation:Optional
+	ReceiverAccountID *string `json:"receiverAccountID,omitempty"`
+	// The name of the resource share.
+	// Only populated in Accept Mode.
+	// +kubebuilder:validation:Optional
+	ShareName *string `json:"shareName,omitempty"`
+	// The date and time when the invitation was sent.
+	// Only populated in Accept Mode.
+	// +kubebuilder:validation:Optional
+	InvitationTime *metav1.Time `json:"invitationTime,omitempty"`
+	// The resources included in the resource share.
+	// Only populated in Accept Mode.
+	// +kubebuilder:validation:Optional
+	Resources []*string `json:"resources,omitempty"`
+	// The current status of the resource share.
+	// Only populated in Accept Mode.
+	// +kubebuilder:validation:Optional
+	ShareStatus *string `json:"shareStatus,omitempty"`
 }
 
 // ResourceShare is the Schema for the ResourceShares API

--- a/config/crd/bases/ram.services.k8s.aws_resourceshares.yaml
+++ b/config/crd/bases/ram.services.k8s.aws_resourceshares.yaml
@@ -41,7 +41,35 @@ spec:
               ResourceShareSpec defines the desired state of ResourceShare.
 
               Describes a resource share in RAM.
+
+              This resource can operate in two modes:
+              1. Create Mode (default): Creates a new resource share and shares resources with principals
+              2. Accept Mode: Accepts an incoming resource share invitation from another account
+
+              To use Accept Mode, set the acceptInvitation field with the ShareARN of the incoming share.
+              In Accept Mode, most other fields (name, principals, resourceARNs, etc.) are ignored.
             properties:
+              acceptInvitation:
+                description: |-
+                  AcceptInvitation configures this resource to accept an incoming share invitation
+                  instead of creating a new share. When set, the controller will:
+                  1. Find the pending invitation for the specified ShareARN
+                  2. Accept the invitation
+                  3. Populate status with invitation details
+
+                  This is mutually exclusive with creating a new share. When acceptInvitation
+                  is set, fields like name, principals, and resourceARNs are ignored.
+
+                  Use this when you want to accept a share from another AWS account.
+                properties:
+                  shareARN:
+                    description: |-
+                      The Amazon Resource Name (ARN) of the resource share to accept.
+                      This should be the ARN of the share that was created by another account.
+                    type: string
+                required:
+                - shareARN
+                type: object
               allowExternalPrincipals:
                 description: |-
                   Specifies whether principals outside your organization in Organizations can
@@ -49,9 +77,14 @@ spec:
                   individual Amazon Web Services accounts that are not in your organization.
                   A value of false only has meaning if your account is a member of an Amazon
                   Web Services Organization. The default value is true.
+
+                  This field is ignored when acceptInvitation is set.
                 type: boolean
               name:
-                description: Specifies the name of the resource share.
+                description: |-
+                  Specifies the name of the resource share.
+
+                  This field is ignored when acceptInvitation is set.
                 type: string
               permissionARNs:
                 description: |-
@@ -60,6 +93,8 @@ spec:
                   specify an ARN for the permission, RAM automatically attaches the default
                   version of the permission for each resource type. You can associate only
                   one permission with each resource type included in the resource share.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   type: string
                 type: array
@@ -104,6 +139,8 @@ spec:
                   Not all resource types can be shared with IAM roles and users. For more information,
                   see Sharing with IAM roles and users (https://docs.aws.amazon.com/ram/latest/userguide/permissions.html#permissions-rbp-supported-resource-types)
                   in the Resource Access Manager User Guide.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   type: string
                 type: array
@@ -111,6 +148,8 @@ spec:
                 description: |-
                   Specifies a list of one or more ARNs of the resources to associate with the
                   resource share.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   type: string
                 type: array
@@ -118,6 +157,8 @@ spec:
                 description: |-
                   Specifies from which source accounts the service principal has access to
                   the resources in this resource share.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   type: string
                 type: array
@@ -126,6 +167,8 @@ spec:
                   A list of one or more tag key and value pairs. The tag key must be present
                   and not be an empty string. The tag value must be present but can be an empty
                   string.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   description: |-
                     A structure containing a tag. A tag is metadata that you can attach to your
@@ -143,8 +186,6 @@ spec:
                       type: string
                   type: object
                 type: array
-            required:
-            - name
             type: object
           status:
             description: ResourceShareStatus defines the observed state of ResourceShare
@@ -240,6 +281,23 @@ spec:
                      but the customer ran the PromoteResourceShareCreatedFromPolicy and that
                      operation is still in progress. This value changes to STANDARD when complete.
                 type: string
+              invitationARN:
+                description: |-
+                  The ARN of the invitation that was accepted.
+                  Only populated in Accept Mode.
+                type: string
+              invitationStatus:
+                description: |-
+                  The current status of the invitation.
+                  Possible values: PENDING, ACCEPTED, REJECTED, EXPIRED
+                  Only populated in Accept Mode.
+                type: string
+              invitationTime:
+                description: |-
+                  The date and time when the invitation was sent.
+                  Only populated in Accept Mode.
+                format: date-time
+                type: string
               lastUpdatedTime:
                 description: The date and time when the resource share was last updated.
                 format: date-time
@@ -247,6 +305,33 @@ spec:
               owningAccountID:
                 description: The ID of the Amazon Web Services account that owns the
                   resource share.
+                type: string
+              receiverAccountID:
+                description: |-
+                  The ID of the AWS account that received the invitation.
+                  Only populated in Accept Mode.
+                type: string
+              resources:
+                description: |-
+                  The resources included in the resource share.
+                  Only populated in Accept Mode.
+                items:
+                  type: string
+                type: array
+              senderAccountID:
+                description: |-
+                  The ID of the AWS account that sent the invitation.
+                  Only populated in Accept Mode.
+                type: string
+              shareName:
+                description: |-
+                  The name of the resource share.
+                  Only populated in Accept Mode.
+                type: string
+              shareStatus:
+                description: |-
+                  The current status of the resource share.
+                  Only populated in Accept Mode.
                 type: string
               status:
                 description: The current status of the resource share.

--- a/examples/resource-share-integrated-modes.yaml
+++ b/examples/resource-share-integrated-modes.yaml
@@ -1,0 +1,93 @@
+---
+# Example 1: Create Mode (Default)
+# This creates a new resource share in Account A and shares resources with Account B
+apiVersion: ram.services.k8s.aws/v1alpha1
+kind: ResourceShare
+metadata:
+  name: my-resource-share
+  namespace: default
+spec:
+  # Create Mode: Specify name and resources to share
+  name: my-shared-resources
+  allowExternalPrincipals: true
+  principals:
+    - "123456789012"  # Account B's AWS account ID
+  resourceARNs:
+    - "arn:aws:ec2:us-west-2:111111111111:subnet/subnet-12345678"
+    - "arn:aws:ec2:us-west-2:111111111111:transit-gateway/tgw-12345678"
+  tags:
+    - key: Environment
+      value: Production
+    - key: Owner
+      value: TeamA
+
+---
+# Example 2: Accept Mode
+# This accepts an incoming resource share invitation in Account B
+apiVersion: ram.services.k8s.aws/v1alpha1
+kind: ResourceShare
+metadata:
+  name: accepted-share-from-account-a
+  namespace: default
+spec:
+  # Accept Mode: Specify acceptInvitation with the ShareARN
+  acceptInvitation:
+    shareARN: "arn:aws:ram:us-west-2:111111111111:resource-share/12345678-1234-1234-1234-123456789012"
+  
+  # Note: In Accept Mode, the following fields are ignored:
+  # - name
+  # - allowExternalPrincipals
+  # - principals
+  # - resourceARNs
+  # - permissionARNs
+  # - sources
+  # - tags
+
+---
+# Example 3: Cross-Account Workflow
+# 
+# Step 1: Account A (Sharer) creates a ResourceShare
+# Deploy this in Account A's cluster:
+apiVersion: ram.services.k8s.aws/v1alpha1
+kind: ResourceShare
+metadata:
+  name: saas-provider-share
+  namespace: default
+spec:
+  name: saas-provider-resources
+  allowExternalPrincipals: true
+  principals:
+    - "999999999999"  # Customer's AWS account ID
+  resourceARNs:
+    - "arn:aws:ec2:us-west-2:111111111111:subnet/subnet-abcdef12"
+
+---
+# Step 2: Account B (Customer) accepts the invitation
+# Deploy this in Account B's cluster:
+apiVersion: ram.services.k8s.aws/v1alpha1
+kind: ResourceShare
+metadata:
+  name: accepted-saas-resources
+  namespace: default
+spec:
+  acceptInvitation:
+    shareARN: "arn:aws:ram:us-west-2:111111111111:resource-share/abcdef12-abcd-abcd-abcd-abcdef123456"
+
+---
+# Example 4: Checking Status in Accept Mode
+# After accepting, the status will include invitation details:
+#
+# status:
+#   ackResourceMetadata:
+#     arn: arn:aws:ram:us-west-2:111111111111:resource-share/abcdef12-abcd-abcd-abcd-abcdef123456
+#   conditions: [...]
+#   invitationARN: arn:aws:ram:us-west-2:111111111111:resource-share-invitation/12345678-1234-1234-1234-123456789012
+#   invitationStatus: ACCEPTED
+#   senderAccountID: "111111111111"
+#   receiverAccountID: "999999999999"
+#   shareName: saas-provider-resources
+#   invitationTime: "2024-01-15T10:30:00Z"
+#   resources:
+#     - "arn:aws:ec2:us-west-2:111111111111:subnet/subnet-abcdef12"
+#   shareStatus: ACCEPTED
+

--- a/helm/crds/ram.services.k8s.aws_resourceshares.yaml
+++ b/helm/crds/ram.services.k8s.aws_resourceshares.yaml
@@ -41,7 +41,35 @@ spec:
               ResourceShareSpec defines the desired state of ResourceShare.
 
               Describes a resource share in RAM.
+
+              This resource can operate in two modes:
+              1. Create Mode (default): Creates a new resource share and shares resources with principals
+              2. Accept Mode: Accepts an incoming resource share invitation from another account
+
+              To use Accept Mode, set the acceptInvitation field with the ShareARN of the incoming share.
+              In Accept Mode, most other fields (name, principals, resourceARNs, etc.) are ignored.
             properties:
+              acceptInvitation:
+                description: |-
+                  AcceptInvitation configures this resource to accept an incoming share invitation
+                  instead of creating a new share. When set, the controller will:
+                  1. Find the pending invitation for the specified ShareARN
+                  2. Accept the invitation
+                  3. Populate status with invitation details
+
+                  This is mutually exclusive with creating a new share. When acceptInvitation
+                  is set, fields like name, principals, and resourceARNs are ignored.
+
+                  Use this when you want to accept a share from another AWS account.
+                properties:
+                  shareARN:
+                    description: |-
+                      The Amazon Resource Name (ARN) of the resource share to accept.
+                      This should be the ARN of the share that was created by another account.
+                    type: string
+                required:
+                - shareARN
+                type: object
               allowExternalPrincipals:
                 description: |-
                   Specifies whether principals outside your organization in Organizations can
@@ -49,9 +77,14 @@ spec:
                   individual Amazon Web Services accounts that are not in your organization.
                   A value of false only has meaning if your account is a member of an Amazon
                   Web Services Organization. The default value is true.
+
+                  This field is ignored when acceptInvitation is set.
                 type: boolean
               name:
-                description: Specifies the name of the resource share.
+                description: |-
+                  Specifies the name of the resource share.
+
+                  This field is ignored when acceptInvitation is set.
                 type: string
               permissionARNs:
                 description: |-
@@ -60,6 +93,8 @@ spec:
                   specify an ARN for the permission, RAM automatically attaches the default
                   version of the permission for each resource type. You can associate only
                   one permission with each resource type included in the resource share.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   type: string
                 type: array
@@ -104,6 +139,8 @@ spec:
                   Not all resource types can be shared with IAM roles and users. For more information,
                   see Sharing with IAM roles and users (https://docs.aws.amazon.com/ram/latest/userguide/permissions.html#permissions-rbp-supported-resource-types)
                   in the Resource Access Manager User Guide.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   type: string
                 type: array
@@ -111,6 +148,8 @@ spec:
                 description: |-
                   Specifies a list of one or more ARNs of the resources to associate with the
                   resource share.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   type: string
                 type: array
@@ -118,6 +157,8 @@ spec:
                 description: |-
                   Specifies from which source accounts the service principal has access to
                   the resources in this resource share.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   type: string
                 type: array
@@ -126,6 +167,8 @@ spec:
                   A list of one or more tag key and value pairs. The tag key must be present
                   and not be an empty string. The tag value must be present but can be an empty
                   string.
+
+                  This field is ignored when acceptInvitation is set.
                 items:
                   description: |-
                     A structure containing a tag. A tag is metadata that you can attach to your
@@ -143,8 +186,6 @@ spec:
                       type: string
                   type: object
                 type: array
-            required:
-            - name
             type: object
           status:
             description: ResourceShareStatus defines the observed state of ResourceShare
@@ -240,6 +281,23 @@ spec:
                      but the customer ran the PromoteResourceShareCreatedFromPolicy and that
                      operation is still in progress. This value changes to STANDARD when complete.
                 type: string
+              invitationARN:
+                description: |-
+                  The ARN of the invitation that was accepted.
+                  Only populated in Accept Mode.
+                type: string
+              invitationStatus:
+                description: |-
+                  The current status of the invitation.
+                  Possible values: PENDING, ACCEPTED, REJECTED, EXPIRED
+                  Only populated in Accept Mode.
+                type: string
+              invitationTime:
+                description: |-
+                  The date and time when the invitation was sent.
+                  Only populated in Accept Mode.
+                format: date-time
+                type: string
               lastUpdatedTime:
                 description: The date and time when the resource share was last updated.
                 format: date-time
@@ -247,6 +305,33 @@ spec:
               owningAccountID:
                 description: The ID of the Amazon Web Services account that owns the
                   resource share.
+                type: string
+              receiverAccountID:
+                description: |-
+                  The ID of the AWS account that received the invitation.
+                  Only populated in Accept Mode.
+                type: string
+              resources:
+                description: |-
+                  The resources included in the resource share.
+                  Only populated in Accept Mode.
+                items:
+                  type: string
+                type: array
+              senderAccountID:
+                description: |-
+                  The ID of the AWS account that sent the invitation.
+                  Only populated in Accept Mode.
+                type: string
+              shareName:
+                description: |-
+                  The name of the resource share.
+                  Only populated in Accept Mode.
+                type: string
+              shareStatus:
+                description: |-
+                  The current status of the resource share.
+                  Only populated in Accept Mode.
                 type: string
               status:
                 description: The current status of the resource share.

--- a/pkg/resource/resource_share/sdk.go
+++ b/pkg/resource/resource_share/sdk.go
@@ -63,6 +63,13 @@ func (rm *resourceManager) sdkFind(
 	defer func() {
 		exit(err)
 	}()
+
+	// Check if we're in Accept Mode (acceptInvitation is set)
+	if r.ko.Spec.AcceptInvitation != nil {
+		return rm.sdkFindAcceptedInvitation(ctx, r)
+	}
+
+	// Original Create Mode logic
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.
@@ -184,6 +191,11 @@ func (rm *resourceManager) sdkFind(
 func (rm *resourceManager) requiredFieldsMissingFromReadManyInput(
 	r *resource,
 ) bool {
+	// In Accept Mode, Name is not required (we use ShareARN instead)
+	if r.ko.Spec.AcceptInvitation != nil {
+		return false
+	}
+	// In Create Mode, Name is required
 	return r.ko.Spec.Name == nil
 
 }
@@ -214,6 +226,19 @@ func (rm *resourceManager) sdkCreate(
 	defer func() {
 		exit(err)
 	}()
+
+	// Check if we're in Accept Mode (acceptInvitation is set)
+	if desired.ko.Spec.AcceptInvitation != nil {
+		return rm.sdkAcceptInvitation(ctx, desired)
+	}
+
+	// Create Mode: Validate that name is provided
+	if desired.ko.Spec.Name == nil || *desired.ko.Spec.Name == "" {
+		return nil, ackerr.NewTerminalError(fmt.Errorf(
+			"spec.name is required when not in Accept Mode (acceptInvitation is not set)"))
+	}
+
+	// Original Create Mode logic
 	input, err := rm.newCreateRequestPayload(ctx, desired)
 	if err != nil {
 		return nil, err
@@ -429,6 +454,15 @@ func (rm *resourceManager) sdkDelete(
 	defer func() {
 		exit(err)
 	}()
+
+	// Check if we're in Accept Mode
+	if r.ko.Spec.AcceptInvitation != nil {
+		// In Accept Mode, we need to reject the invitation or leave the share
+		// We don't own the share, so we can't delete it
+		return rm.sdkRejectOrLeaveShare(ctx, r)
+	}
+
+	// Create Mode: Delete the resource share we own
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
 		return nil, err
@@ -438,6 +472,142 @@ func (rm *resourceManager) sdkDelete(
 	resp, err = rm.sdkapi.DeleteResourceShare(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteResourceShare", err)
 	return nil, err
+}
+
+// sdkRejectOrLeaveShare handles deletion for Accept Mode resources
+// In Accept Mode, we don't own the share, so we need to handle cleanup:
+// 1. If invitation is PENDING: Reject it using RejectResourceShareInvitation
+// 2. If invitation is ACCEPTED: Leave the share using DisassociateResourceShare
+//
+// IMPORTANT: AWS Resource Type Limitations
+// -----------------------------------------
+// Some AWS resource types do not support self-disassociation from resource shares.
+// When a share contains these resource types, attempting to leave the share will
+// result in an OperationNotPermittedException error.
+//
+// Known resource types with this limitation:
+//   - Network Firewall (network-firewall:StatefulRulegroup, network-firewall:StatelessRulegroup, etc.)
+//
+// For these resource types:
+//   - Only the share OWNER can remove principals from the share
+//   - The receiver CANNOT leave the share themselves
+//   - AWS error message: "You cannot leave resource share [...]. The share contains
+//     resources of the following resource types, which don't support this action: [...]"
+//
+// Handling Strategy:
+//   - When OperationNotPermittedException is encountered during deletion, we treat it
+//     as a successful deletion to allow the Kubernetes resource to be cleaned up
+//   - The AWS invitation will remain in ACCEPTED state until the share owner removes
+//     the principal or deletes the share
+//   - This prevents the Kubernetes resource from getting stuck with a finalizer
+//   - A warning is logged to inform operators about the limitation
+//
+// This is expected AWS behavior and not a bug in the controller.
+func (rm *resourceManager) sdkRejectOrLeaveShare(
+	ctx context.Context,
+	r *resource,
+) (latest *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	rlog.Info("Cleaning up resource share in Accept Mode")
+
+	// Get the invitation ARN, status, and share ARN from the resource
+	invitationARN := r.ko.Status.InvitationARN
+	invitationStatus := r.ko.Status.InvitationStatus
+	shareARN := r.ko.Spec.AcceptInvitation.ShareARN
+
+	if shareARN == nil {
+		rlog.Info("No ShareARN in spec, nothing to clean up")
+		return nil, nil
+	}
+
+	if invitationARN == nil || *invitationARN == "" {
+		// No invitation ARN in status, try to find it
+		listInput := &svcsdk.GetResourceShareInvitationsInput{
+			ResourceShareArns: []string{*shareARN},
+		}
+
+		listResp, err := rm.sdkapi.GetResourceShareInvitations(ctx, listInput)
+		rm.metrics.RecordAPICall("READ_MANY", "GetResourceShareInvitations", err)
+		if err != nil {
+			rlog.Info("Failed to find invitation, may already be cleaned up", "error", err)
+			return nil, nil
+		}
+
+		// Find the invitation (pending or accepted)
+		for _, inv := range listResp.ResourceShareInvitations {
+			if inv.Status == svcsdktypes.ResourceShareInvitationStatusPending ||
+				inv.Status == svcsdktypes.ResourceShareInvitationStatusAccepted {
+				invitationARN = inv.ResourceShareInvitationArn
+				invitationStatus = aws.String(string(inv.Status))
+				break
+			}
+		}
+
+		if invitationARN == nil {
+			rlog.Info("No invitation found, nothing to clean up")
+			return nil, nil
+		}
+	}
+
+	// Check the invitation status
+	if invitationStatus != nil && *invitationStatus == "ACCEPTED" {
+		// For accepted invitations, we need to disassociate ourselves as a principal
+		// This is what the AWS GUI "Leave" button does
+		rlog.Info("Leaving accepted resource share by disassociating principal",
+			"shareARN", *shareARN)
+
+		// Get our account ID
+		accountID := r.ko.Status.ReceiverAccountID
+		if accountID == nil || *accountID == "" {
+			rlog.Info("No receiver account ID in status, cannot disassociate")
+			return nil, ackerr.NewTerminalError(fmt.Errorf("receiver account ID not found in status"))
+		}
+
+		// Disassociate ourselves as a principal from the share
+		disassociateInput := &svcsdk.DisassociateResourceShareInput{
+			ResourceShareArn: shareARN,
+			Principals:       []string{*accountID},
+		}
+
+		_, err = rm.sdkapi.DisassociateResourceShare(ctx, disassociateInput)
+		rm.metrics.RecordAPICall("DELETE", "DisassociateResourceShare", err)
+		if err != nil {
+			// Check if this is an OperationNotPermittedException
+			// Some resource types (e.g., Network Firewall) don't support self-disassociation
+			// In this case, only the share owner can remove the principal
+			if strings.Contains(err.Error(), "OperationNotPermittedException") {
+				rlog.Info("Cannot leave resource share - resource type does not support self-disassociation. " +
+					"Only the share owner can remove you from this share. " +
+					"Treating as successful deletion to avoid resource getting stuck.",
+					"error", err)
+				// Return success to allow the Kubernetes resource to be deleted
+				// The AWS invitation will remain ACCEPTED until the owner removes the principal
+				return nil, nil
+			}
+
+			rlog.Info("Failed to disassociate from resource share", "error", err)
+			return nil, err
+		}
+
+		rlog.Info("Successfully left resource share")
+		return nil, nil
+	}
+
+	// Invitation is PENDING - we can reject it
+	rlog.Info("Rejecting pending resource share invitation", "invitationARN", *invitationARN)
+	rejectInput := &svcsdk.RejectResourceShareInvitationInput{
+		ResourceShareInvitationArn: invitationARN,
+	}
+
+	_, err = rm.sdkapi.RejectResourceShareInvitation(ctx, rejectInput)
+	rm.metrics.RecordAPICall("DELETE", "RejectResourceShareInvitation", err)
+	if err != nil {
+		rlog.Info("Failed to reject resource share invitation", "error", err)
+		return nil, err
+	}
+
+	rlog.Info("Successfully rejected resource share invitation")
+	return nil, nil
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request
@@ -567,4 +737,248 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	default:
 		return false
 	}
+}
+
+// sdkFindAcceptedInvitation finds an accepted invitation for the specified ShareARN
+// This is used when spec.acceptInvitation is set (Accept Mode)
+func (rm *resourceManager) sdkFindAcceptedInvitation(
+	ctx context.Context,
+	r *resource,
+) (latest *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkFindAcceptedInvitation")
+	defer func() {
+		exit(err)
+	}()
+
+	if r.ko.Spec.AcceptInvitation == nil || r.ko.Spec.AcceptInvitation.ShareARN == nil {
+		return nil, ackerr.NotFound
+	}
+
+	// Get the invitation for this share ARN
+	input := &svcsdk.GetResourceShareInvitationsInput{
+		ResourceShareArns: []string{*r.ko.Spec.AcceptInvitation.ShareARN},
+	}
+
+	var resp *svcsdk.GetResourceShareInvitationsOutput
+	resp, err = rm.sdkapi.GetResourceShareInvitations(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetResourceShareInvitations", err)
+	if err != nil {
+		var awsErr smithy.APIError
+		if errors.As(err, &awsErr) {
+			if awsErr.ErrorCode() == "ResourceShareInvitationArnNotFoundException" ||
+				awsErr.ErrorCode() == "UnknownResourceException" {
+				return nil, ackerr.NotFound
+			}
+		}
+		return nil, err
+	}
+
+	// Find the accepted invitation for this share
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+	found := false
+	var acceptedInvitationARN *string
+
+	for _, invitation := range resp.ResourceShareInvitations {
+		// We're looking for an ACCEPTED invitation for this share
+		if invitation.Status == svcsdktypes.ResourceShareInvitationStatusAccepted {
+			found = true
+			acceptedInvitationARN = invitation.ResourceShareInvitationArn
+			rm.setResourceFromInvitation(ko, &invitation)
+			break
+		}
+	}
+
+	if !found {
+		return nil, ackerr.NotFound
+	}
+
+	// Populate resources associated with the invitation
+	// This uses the ListPendingInvitationResources API (non-deprecated)
+	if acceptedInvitationARN != nil {
+		_ = rm.populateInvitationResources(ctx, ko, acceptedInvitationARN)
+	}
+
+	return &resource{ko}, nil
+}
+
+// sdkAcceptInvitation accepts a pending resource share invitation
+// This is used when spec.acceptInvitation is set (Accept Mode)
+//
+// Accept Mode Overview:
+// ---------------------
+// In Accept Mode, the ResourceShare CRD is used to accept an incoming resource share
+// invitation from another AWS account (cross-account sharing). The workflow is:
+//
+// 1. Account A (sender) creates a resource share and shares it with Account B (receiver)
+// 2. AWS RAM sends an invitation to Account B
+// 3. Account B creates a ResourceShare with spec.acceptInvitation.shareARN set
+// 4. The controller accepts the invitation and populates status fields
+//
+// Deletion Behavior:
+// ------------------
+// When deleting a ResourceShare in Accept Mode:
+//   - PENDING invitations: Rejected using RejectResourceShareInvitation
+//   - ACCEPTED invitations: Left using DisassociateResourceShare (if supported)
+//
+// IMPORTANT: Some resource types (e.g., Network Firewall) do not support self-disassociation.
+// For these resources, the Kubernetes resource will be deleted successfully, but the AWS
+// invitation will remain ACCEPTED until the share owner removes the principal.
+// See sdkRejectOrLeaveShare() for detailed documentation on this limitation.
+func (rm *resourceManager) sdkAcceptInvitation(
+	ctx context.Context,
+	desired *resource,
+) (created *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkAcceptInvitation")
+	defer func() {
+		exit(err)
+	}()
+
+	if desired.ko.Spec.AcceptInvitation == nil || desired.ko.Spec.AcceptInvitation.ShareARN == nil {
+		return nil, fmt.Errorf("ShareARN is required in acceptInvitation")
+	}
+
+	// First, find the pending invitation for this share ARN
+	getInput := &svcsdk.GetResourceShareInvitationsInput{
+		ResourceShareArns: []string{*desired.ko.Spec.AcceptInvitation.ShareARN},
+	}
+
+	var getResp *svcsdk.GetResourceShareInvitationsOutput
+	getResp, err = rm.sdkapi.GetResourceShareInvitations(ctx, getInput)
+	rm.metrics.RecordAPICall("READ_ONE", "GetResourceShareInvitations", err)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find a pending invitation
+	var pendingInvitationARN *string
+	for _, invitation := range getResp.ResourceShareInvitations {
+		if invitation.Status == svcsdktypes.ResourceShareInvitationStatusPending {
+			pendingInvitationARN = invitation.ResourceShareInvitationArn
+			break
+		}
+	}
+
+	if pendingInvitationARN == nil {
+		return nil, ackerr.NewTerminalError(fmt.Errorf("no pending invitation found for share ARN %s. "+
+			"NOTE: If both AWS accounts are in the same AWS Organization and RAM Sharing with AWS Organizations is enabled, "+
+			"this resource is not necessary", *desired.ko.Spec.AcceptInvitation.ShareARN))
+	}
+
+	// Accept the invitation
+	acceptInput := &svcsdk.AcceptResourceShareInvitationInput{
+		ResourceShareInvitationArn: pendingInvitationARN,
+	}
+
+	var acceptResp *svcsdk.AcceptResourceShareInvitationOutput
+	acceptResp, err = rm.sdkapi.AcceptResourceShareInvitation(ctx, acceptInput)
+	rm.metrics.RecordAPICall("CREATE", "AcceptResourceShareInvitation", err)
+	if err != nil {
+		return nil, err
+	}
+
+	ko := desired.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+	rm.setResourceFromInvitation(ko, acceptResp.ResourceShareInvitation)
+
+	// Populate resources associated with the invitation
+	// This uses the ListPendingInvitationResources API (non-deprecated)
+	if acceptResp.ResourceShareInvitation != nil && acceptResp.ResourceShareInvitation.ResourceShareInvitationArn != nil {
+		_ = rm.populateInvitationResources(ctx, ko, acceptResp.ResourceShareInvitation.ResourceShareInvitationArn)
+	}
+
+	return &resource{ko}, nil
+}
+
+// setResourceFromInvitation populates the resource status from an invitation
+// This is used in Accept Mode to populate invitation-specific status fields
+func (rm *resourceManager) setResourceFromInvitation(
+	ko *svcapitypes.ResourceShare,
+	invitation *svcsdktypes.ResourceShareInvitation,
+) {
+	if invitation == nil {
+		return
+	}
+
+	// Set invitation-specific status fields
+	if invitation.ResourceShareInvitationArn != nil {
+		ko.Status.InvitationARN = invitation.ResourceShareInvitationArn
+	}
+	if invitation.Status != "" {
+		ko.Status.InvitationStatus = aws.String(string(invitation.Status))
+	}
+	if invitation.SenderAccountId != nil {
+		ko.Status.SenderAccountID = invitation.SenderAccountId
+	}
+	if invitation.ReceiverAccountId != nil {
+		ko.Status.ReceiverAccountID = invitation.ReceiverAccountId
+	}
+	if invitation.ResourceShareName != nil {
+		ko.Status.ShareName = invitation.ResourceShareName
+	}
+	if invitation.InvitationTimestamp != nil {
+		ko.Status.InvitationTime = &metav1.Time{*invitation.InvitationTimestamp}
+	}
+	if invitation.ResourceShareArn != nil {
+		arn := ackv1alpha1.AWSResourceName(*invitation.ResourceShareArn)
+		if ko.Status.ACKResourceMetadata == nil {
+			ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+		}
+		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
+
+	// Set share status
+	if invitation.Status != "" {
+		ko.Status.ShareStatus = aws.String(string(invitation.Status))
+	}
+}
+
+// populateInvitationResources fetches and populates the resources associated with an invitation
+// Uses the ListPendingInvitationResources API (replaces deprecated ResourceShareAssociations field)
+func (rm *resourceManager) populateInvitationResources(
+	ctx context.Context,
+	ko *svcapitypes.ResourceShare,
+	invitationARN *string,
+) error {
+	rlog := ackrtlog.FromContext(ctx)
+
+	if invitationARN == nil {
+		return nil
+	}
+
+	rlog.Info("Fetching resources for invitation using ListPendingInvitationResources API",
+		"invitationARN", *invitationARN)
+
+	// List resources associated with the pending invitation
+	input := &svcsdk.ListPendingInvitationResourcesInput{
+		ResourceShareInvitationArn: invitationARN,
+	}
+
+	resp, err := rm.sdkapi.ListPendingInvitationResources(ctx, input)
+	rm.metrics.RecordAPICall("READ", "ListPendingInvitationResources", err)
+	if err != nil {
+		// Don't fail the whole operation if we can't list resources
+		// Just log and continue
+		rlog.Info("Failed to list pending invitation resources (non-fatal)", "error", err)
+		return nil
+	}
+
+	if resp.Resources != nil && len(resp.Resources) > 0 {
+		resources := make([]*string, 0, len(resp.Resources))
+		for _, resource := range resp.Resources {
+			if resource.Arn != nil {
+				resources = append(resources, resource.Arn)
+			}
+		}
+		if len(resources) > 0 {
+			ko.Status.Resources = resources
+			rlog.Info("Populated resources from invitation", "resourceCount", len(resources))
+		}
+	} else {
+		rlog.Info("No resources found in invitation")
+	}
+
+	return nil
 }

--- a/test/e2e/ram_resource_share.py
+++ b/test/e2e/ram_resource_share.py
@@ -137,3 +137,68 @@ def list_associated_resources(arn):
             return resp['resourceShareAssociations'][0]
     except c.UnknownResourceException:
         return None
+
+
+def get_resource_share_invitations(share_arn=None):
+    """Returns resource share invitations.
+
+    Args:
+        share_arn: Optional ShareARN to filter invitations
+
+    Returns:
+        List of invitations, or None if error
+    """
+    c = boto3.client('ram')
+    try:
+        params = {}
+        if share_arn:
+            params['resourceShareArns'] = [share_arn]
+
+        resp = c.get_resource_share_invitations(**params)
+        if 'resourceShareInvitations' in resp:
+            return resp['resourceShareInvitations']
+        return []
+    except Exception as e:
+        return None
+
+
+def accept_resource_share_invitation(invitation_arn):
+    """Accepts a resource share invitation.
+
+    Args:
+        invitation_arn: ARN of the invitation to accept
+
+    Returns:
+        The accepted invitation details, or None if error
+    """
+    c = boto3.client('ram')
+    try:
+        resp = c.accept_resource_share_invitation(
+            resourceShareInvitationArn=invitation_arn
+        )
+        if 'resourceShareInvitation' in resp:
+            return resp['resourceShareInvitation']
+        return None
+    except Exception as e:
+        return None
+
+
+def reject_resource_share_invitation(invitation_arn):
+    """Rejects a resource share invitation.
+
+    Args:
+        invitation_arn: ARN of the invitation to reject
+
+    Returns:
+        The rejected invitation details, or None if error
+    """
+    c = boto3.client('ram')
+    try:
+        resp = c.reject_resource_share_invitation(
+            resourceShareInvitationArn=invitation_arn
+        )
+        if 'resourceShareInvitation' in resp:
+            return resp['resourceShareInvitation']
+        return None
+    except Exception as e:
+        return None

--- a/test/e2e/resources/ram_resource_share_accept_mode.yaml
+++ b/test/e2e/resources/ram_resource_share_accept_mode.yaml
@@ -1,0 +1,8 @@
+apiVersion: ram.services.k8s.aws/v1alpha1
+kind: ResourceShare
+metadata:
+  name: $RESOURCE_SHARE_NAME
+spec:
+  acceptInvitation:
+    shareARN: $SHARE_ARN
+

--- a/test/e2e/resources/ram_resource_share_no_name.yaml
+++ b/test/e2e/resources/ram_resource_share_no_name.yaml
@@ -1,0 +1,8 @@
+apiVersion: ram.services.k8s.aws/v1alpha1
+kind: ResourceShare
+metadata:
+  name: $RESOURCE_SHARE_NAME
+spec:
+  # Create Mode without name - should fail validation
+  allowExternalPrincipals: true
+

--- a/test/e2e/tests/test_resource_share_accept_mode.py
+++ b/test/e2e/tests/test_resource_share_accept_mode.py
@@ -1,0 +1,147 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for the ResourceShare Accept Mode functionality.
+
+Accept Mode allows a ResourceShare to accept an incoming share invitation
+from another AWS account, rather than creating a new share.
+"""
+
+import pytest
+import time
+import logging
+
+from acktest.resources import random_suffix_name
+from acktest.k8s import resource as k8s
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ram_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+
+RESOURCE_KIND = "ResourceShare"
+RESOURCE_PLURAL = "resourceshares"
+
+CREATE_WAIT_AFTER_SECONDS = 10
+DELETE_WAIT_AFTER_SECONDS = 20
+
+
+@service_marker
+class TestResourceShareAcceptMode:
+    """Tests for ResourceShare Accept Mode functionality.
+    
+    Accept Mode is used when you want to accept a resource share invitation
+    from another AWS account, rather than creating a new share.
+    """
+
+    def test_create_mode_name_validation(self):
+        """Test that creating a ResourceShare in Create Mode without a name fails.
+        
+        When acceptInvitation is NOT set (Create Mode), the name field is required.
+        This test verifies that the controller returns a Terminal error when name is missing.
+        """
+        resource_name = random_suffix_name("no-name-test", 24)
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["RESOURCE_SHARE_NAME"] = resource_name
+
+        # Load ResourceShare CR without name field
+        resource_data = load_ram_resource(
+            "ram_resource_share_no_name",
+            additional_replacements=replacements,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        # Verify resource has Terminal error condition
+        cr = k8s.get_resource(ref)
+        assert cr is not None
+        assert 'status' in cr
+        assert 'conditions' in cr['status']
+        
+        # Check for ACK.Terminal condition
+        terminal_condition = None
+        for condition in cr['status']['conditions']:
+            if condition['type'] == 'ACK.Terminal':
+                terminal_condition = condition
+                break
+        
+        assert terminal_condition is not None, "Expected ACK.Terminal condition"
+        assert terminal_condition['status'] == 'True', "Expected Terminal condition to be True"
+        assert 'name is required' in terminal_condition['message'].lower(), \
+            f"Expected error message about name being required, got: {terminal_condition['message']}"
+        
+        logging.info(f"Terminal error message: {terminal_condition['message']}")
+
+        # Clean up
+        k8s.delete_custom_resource(ref, period_length=DELETE_WAIT_AFTER_SECONDS)
+
+    @pytest.mark.skip(reason="Requires cross-account setup with actual invitation")
+    def test_accept_mode_happy_path(self):
+        """Test accepting a resource share invitation (Accept Mode).
+        
+        This test requires:
+        1. Another AWS account (Account A) to create a resource share
+        2. An invitation sent to the test account (Account B)
+        3. The ShareARN of the invitation
+        
+        TODO: Implement this test when cross-account test infrastructure is available.
+        
+        Expected behavior:
+        - ResourceShare is created with acceptInvitation field
+        - Controller finds the pending invitation
+        - Controller accepts the invitation
+        - Status fields are populated: invitationARN, invitationStatus, senderAccountID, etc.
+        - Invitation status becomes ACCEPTED
+        """
+        pass
+
+    @pytest.mark.skip(reason="Requires cross-account setup with actual invitation")
+    def test_accept_mode_deletion(self):
+        """Test deleting a ResourceShare in Accept Mode.
+        
+        This test requires:
+        1. An accepted resource share invitation
+        2. A ResourceShare in Accept Mode that has accepted the invitation
+        
+        TODO: Implement this test when cross-account test infrastructure is available.
+        
+        Expected behavior:
+        - When deleting a ResourceShare with ACCEPTED invitation:
+          - Controller calls DisassociateResourceShare (leaves the share)
+          - Invitation is cleaned up in AWS
+          - Kubernetes resource is deleted
+        """
+        pass
+
+    @pytest.mark.skip(reason="Requires cross-account setup with actual invitation")
+    def test_accept_mode_nonexistent_invitation(self):
+        """Test accepting a non-existent invitation.
+        
+        This test verifies error handling when trying to accept an invitation
+        that doesn't exist.
+        
+        TODO: Implement this test when cross-account test infrastructure is available.
+        
+        Expected behavior:
+        - ResourceShare is created with acceptInvitation pointing to non-existent share
+        - Controller returns Terminal error
+        - Error message indicates no pending invitation found
+        """
+        pass
+


### PR DESCRIPTION
**NOTE** - Code has been generated using AI

## Overview

This PR implements resource share invitation acceptance functionality by **integrating it into the existing ResourceShare CRD** rather than creating a separate ResourceShareAcceptor CRD. This approach was explored in response to reviewer feedback on [PR #43](https://github.com/aws-controllers-k8s/ram-controller/pull/43) suggesting consideration of an integrated solution similar to EKS AccessPolicies.

## Approach: Integrated vs Separate CRD

### Integrated Approach (This PR)
**Single CRD with dual-mode operation:**
- Same `ResourceShare` CRD operates in two modes based on spec fields
- **Create Mode** (default): Creates a new resource share (existing functionality)
- **Accept Mode**: Accepts an incoming invitation (new functionality)
- Mode determined by presence of `spec.acceptInvitation` field

### Key Differences from Separate CRD Approach

| Aspect | Integrated (This PR) | Separate CRD |
|--------|---------------------|--------------|
| **API Surface** | Single CRD, dual-mode | Two separate CRDs |
| **User Experience** | One resource type to learn | Two resource types |
| **Code Complexity** | Conditional logic in one controller | Two separate controllers |
| **Field Validation** | Some fields ignored in Accept Mode | All fields relevant |
| **Status Fields** | Different fields populated per mode | Dedicated status per CRD |
| **Cross-Account Pattern** | Same resource type in both accounts | Different resource types |

## Implementation Details

### 1. CRD Changes

#### New Spec Fields
```yaml
spec:
  # New field to enable Accept Mode
  acceptInvitation:
    shareARN: "arn:aws:ram:..."
  
  # Existing field, now optional
  name: "my-share"  # Required in Create Mode, ignored in Accept Mode
```

#### New Status Fields (Accept Mode only)
```yaml
status:
  invitationARN: "arn:aws:ram:..."
  invitationStatus: "ACCEPTED"
  invitationTime: "2026-02-17T10:34:27Z"
  senderAccountID: "592111036196"
  receiverAccountID: "065002218531"
  shareName: "rhys-test"
  shareStatus: "ACCEPTED"
  resources:
    - "arn:aws:network-firewall:..."
```

### 2. Controller Logic

#### Mode Detection
```go
if desired.ko.Spec.AcceptInvitation != nil {
    // Accept Mode: Route to invitation acceptance logic
    return rm.sdkAcceptInvitation(ctx, desired)
}
// Create Mode: Original resource share creation logic
```

#### Accept Mode Operations
- **Create**: Accepts pending invitation using `AcceptResourceShareInvitation`
- **Read**: Finds accepted invitation using `GetResourceShareInvitations`
- **Delete**: Rejects (PENDING) or leaves (ACCEPTED) using appropriate APIs

### 3. Deletion Handling

Two different deletion paths based on invitation status:

**PENDING Invitations:**
```go
RejectResourceShareInvitation(invitationARN)
```

**ACCEPTED Invitations:**
```go
DisassociateResourceShare(shareARN, principals: [accountID])
```

### 4. AWS Limitation Handling

**Problem:** Some AWS resource types (e.g., Network Firewall) don't support self-disassociation.

**Error from AWS:**
```
OperationNotPermittedException: You cannot leave resource share [...]. 
The share contains resources of the following resource types, which don't 
support this action: [network-firewall:StatefulRulegroup].
```

**Solution:** Gracefully handle the error and allow Kubernetes resource deletion:
```go
if strings.Contains(err.Error(), "OperationNotPermittedException") {
    // Log warning and treat as successful deletion
    // AWS invitation remains ACCEPTED until owner removes principal
    return nil, nil
}
```

This prevents resources from getting stuck with finalizers while documenting the AWS limitation.

### 5. Deprecated API Replacement

**Removed:** Usage of deprecated `ResourceShareAssociations` field

**Replaced with:** `ListPendingInvitationResources` API
```go
func (rm *resourceManager) populateInvitationResources(
    ctx context.Context,
    ko *svcapitypes.ResourceShare,
    invitationARN *string,
) error {
    resp, err := rm.sdkapi.ListPendingInvitationResources(ctx, input)
    // Populate status.resources with resource ARNs
}
```

## Testing Results

### Test Scenario: Accept Invitation with Network Firewall Resource

**Input:**
- Share ARN: `arn:aws:ram:us-east-2:59211111111:resource-share/...`
- Resource: Network Firewall stateful rule group

**Output After Acceptance:**
```yaml
status:
  invitationStatus: ACCEPTED
  resources:
    - arn:aws:network-firewall:us-east-2:59211111111:stateful-rulegroup/rhys-test-firewall
  senderAccountID: "59211111111"
  receiverAccountID: "065002222222"
  shareName: rhys-test
```

**Deletion Test:**
- ✅ Kubernetes resource deleted successfully
- ✅ OperationNotPermittedException handled gracefully
- ℹ️ AWS invitation remains ACCEPTED (expected for Network Firewall)

### Controller Logs
```json
{"msg":"Fetching resources for invitation using ListPendingInvitationResources API"}
{"msg":"Populated resources from invitation","resourceCount":1}
{"msg":"Cannot leave resource share - resource type does not support self-disassociation"}
{"msg":"deleted resource"}
```

## Validation

### Name Field Validation
Added validation to ensure `name` is provided in Create Mode:
```go
if desired.ko.Spec.Name == nil || *desired.ko.Spec.Name == "" {
    return nil, ackerr.NewTerminalError(fmt.Errorf(
        "spec.name is required when not in Accept Mode"))
}
```

## Documentation

### Code Documentation
- Comprehensive function-level documentation for Accept Mode workflow
- Detailed explanation of AWS resource type limitations
- Inline comments for error handling logic

### Examples
Created `examples/resource-share-integrated-modes.yaml` with:
- Create Mode example
- Accept Mode example
- Cross-account workflow example
- Status field documentation

### E2E Tests
- `test_resource_share_accept_mode.py` with Accept Mode test cases
- Name validation test (implemented)
- Cross-account tests (documented, require infrastructure)

## Trade-offs Analysis

### Advantages of Integrated Approach
1. ✅ **Simpler mental model** - One resource type for all RAM operations
2. ✅ **Consistent API** - Same CRD in both sender and receiver accounts
3. ✅ **Less code duplication** - Shared validation, status handling, etc.
4. ✅ **Easier discovery** - Users only need to learn one CRD

### Disadvantages of Integrated Approach
1. ⚠️ **Field confusion** - Some fields ignored in Accept Mode
2. ⚠️ **Conditional logic** - More complex controller code
3. ⚠️ **Validation complexity** - Different requirements per mode

### Advantages of Separate CRD Approach
1. ✅ **Clear separation** - Each CRD has dedicated purpose
2. ✅ **Simpler validation** - All fields always relevant
3. ✅ **Explicit intent** - Resource type indicates operation

### Disadvantages of Separate CRD Approach
1. ⚠️ **More API surface** - Two CRDs to learn and maintain
2. ⚠️ **Code duplication** - Similar logic in two controllers
3. ⚠️ **Inconsistent pattern** - Different resources for related operations

## Recommendation

The integrated approach is **recommended** for the following reasons:

1. **Aligns with AWS RAM conceptual model** - Both operations deal with "resource shares"
2. **Simpler user experience** - One CRD to learn, consistent across accounts
3. **Follows Kubernetes patterns** - Similar to how other controllers handle dual modes
4. **Easier to maintain** - Single controller with shared logic

However, if the ACK project prefers **explicit separation of concerns**, the separate CRD approach is also valid and was the original implementation in PR #43.

## Files Changed

- `apis/v1alpha1/resource_share.go` - CRD definition with Accept Mode fields
- `pkg/resource/resource_share/sdk.go` - Accept Mode implementation
- `config/crd/bases/ram.services.k8s.aws_resourceshares.yaml` - Generated CRD
- `helm/crds/ram.services.k8s.aws_resourceshares.yaml` - Helm CRD
- `test/e2e/tests/test_resource_share_accept_mode.py` - E2E tests
- `examples/resource-share-integrated-modes.yaml` - Usage examples

**Total:** 9 files changed, 992 insertions(+), 8 deletions(-)

## Next Steps

Please review this integrated approach and provide feedback on:
1. Whether the integrated approach is preferred over separate CRDs
2. Any concerns about field validation or user experience
3. Whether additional documentation is needed
4. Any other implementation considerations

I'm happy to adjust the implementation based on your feedback or revert to the separate CRD approach if preferred.

Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/2786

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
