### PR TITLE
fix_resource_share_adoption_bug: Fix resource share adoption bug

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-03-11T18:48:29Z"
+  build_date: "2026-03-11T20:58:54Z"
   build_hash: 5ac6c79fbc941c426d8b70cba768820fc9296542
-  go_version: go1.25.7
-  version: v0.58.0
+  go_version: go1.25.0
+  version: v0.58.0-dirty
 api_directory_checksum: e3ea3d54f0e513853e3b8fd85fa0c386fb01459b
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-03-11T20:58:54Z"
-  build_hash: 5ac6c79fbc941c426d8b70cba768820fc9296542
-  go_version: go1.25.0
-  version: v0.58.0-dirty
+  build_date: "2026-03-30T19:00:47Z"
+  build_hash: f0b080577c1ea030a347541b1f7a81843f33c9b6
+  go_version: go1.26.0
+  version: v0.58.0-2-gf0b0805
 api_directory_checksum: e3ea3d54f0e513853e3b8fd85fa0c386fb01459b
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/resource_share/sdk.go
+++ b/pkg/resource/resource_share/sdk.go
@@ -74,9 +74,10 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
-	if r.ko.Status.OwningAccountID != nil && *r.ko.Status.OwningAccountID == string(rm.awsAccountID) {
-		input.ResourceOwner = svcsdktypes.ResourceOwnerSelf
-	} else {
+
+	// defaults owner to Self, only change if we know it's owned by another account
+	input.ResourceOwner = svcsdktypes.ResourceOwnerSelf
+	if r.ko.Status.OwningAccountID != nil && *r.ko.Status.OwningAccountID != string(rm.awsAccountID) {
 		input.ResourceOwner = svcsdktypes.ResourceOwnerOtherAccounts
 	}
 	var resp *svcsdk.GetResourceSharesOutput

--- a/templates/hooks/resource_share/sdk_find_read_many_post_build_request.go.tpl
+++ b/templates/hooks/resource_share/sdk_find_read_many_post_build_request.go.tpl
@@ -1,5 +1,6 @@
-	if r.ko.Status.OwningAccountID != nil && *r.ko.Status.OwningAccountID == string(rm.awsAccountID) {
-		input.ResourceOwner = svcsdktypes.ResourceOwnerSelf
-	} else {
+
+	// defaults owner to Self, only change if we know it's owned by another account
+	input.ResourceOwner = svcsdktypes.ResourceOwnerSelf
+	if r.ko.Status.OwningAccountID != nil && *r.ko.Status.OwningAccountID != string(rm.awsAccountID) {
 		input.ResourceOwner = svcsdktypes.ResourceOwnerOtherAccounts
 	}


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-controllers-k8s/community/issues/2819

**Description of changes:**
This PR fixes the `sdkFind()` function for ResourceShare to default the owning Account to Self if its `nil` rather than OtherAccount. 
This fixes the issue (linked above) where a resource share exists in the aws account but the controller still can't find it because it is looking for it in OtherAccount.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
