### PR TITLE
Mark Permission.PolicyTemplate as is_document

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:39:02Z"
-  build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
-  version: v0.59.1
+  build_date: "2026-06-19T20:10:01Z"
+  build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
+  go_version: go1.26.0
+  version: v0.59.1-7-g2970ca9
 api_directory_checksum: e3ea3d54f0e513853e3b8fd85fa0c386fb01459b
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 5faa7bb173b28ca5cdaa7304f0774dc03bfd9507
+  file_checksum: d839a4e49aed6b50122aaaca5e3944674564691c
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -35,6 +35,9 @@ resources:
       sdk_read_many_post_set_output:
         template_path: hooks/resource_share/sdk_read_many_post_set_output.go.tpl
   Permission:
+    fields:
+      PolicyTemplate:
+        is_document: true
     exceptions:
       terminal_codes:
         - InvalidParameterException

--- a/generator.yaml
+++ b/generator.yaml
@@ -35,6 +35,9 @@ resources:
       sdk_read_many_post_set_output:
         template_path: hooks/resource_share/sdk_read_many_post_set_output.go.tpl
   Permission:
+    fields:
+      PolicyTemplate:
+        is_document: true
     exceptions:
       terminal_codes:
         - InvalidParameterException

--- a/pkg/resource/permission/delta.go
+++ b/pkg/resource/permission/delta.go
@@ -51,7 +51,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.PolicyTemplate, b.ko.Spec.PolicyTemplate) {
 		delta.Add("Spec.PolicyTemplate", a.ko.Spec.PolicyTemplate, b.ko.Spec.PolicyTemplate)
 	} else if a.ko.Spec.PolicyTemplate != nil && b.ko.Spec.PolicyTemplate != nil {
-		if *a.ko.Spec.PolicyTemplate != *b.ko.Spec.PolicyTemplate {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.PolicyTemplate, *b.ko.Spec.PolicyTemplate); err != nil || !equal {
 			delta.Add("Spec.PolicyTemplate", a.ko.Spec.PolicyTemplate, b.ko.Spec.PolicyTemplate)
 		}
 	}


### PR DESCRIPTION
## Summary

Adds is_document: true annotation to Permission.PolicyTemplate field in generator.yaml.

## Problem

The Permission.PolicyTemplate field accepts a JSON policy template document with Effect and Action elements. Without the is_document annotation, the controller uses strict string comparison which causes false drift detection and infinite reconciliation loops when the API returns reformatted (but semantically equivalent) JSON.

Note: Although the PolicyTemplate uses IAM-like syntax (Effect/Action), it is not a full IAM policy document (no Version/Statement wrapper). Using is_document with DocumentEqual is the correct annotation for generic JSON semantic comparison.

## Changes

- Added is_document: true to Permission.PolicyTemplate in generator.yaml
- Regenerated controller code - delta.go now uses DocumentEqual for semantic comparison

## Testing

- go build ./cmd/controller - compiles cleanly
- Existing e2e test (ram_permission.yaml fixture) exercises the policyTemplate field with JSON content and updates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.