### PR TITLE
feat: make ARN unique identifier for AWS Resource Shares

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-07-07T22:01:53Z"
+  build_date: "2026-07-20T17:55:19Z"
   build_hash: 0a6b791fa10a6140d862be334a6891868ee588eb
-  go_version: go1.26.4
+  go_version: go1.26.5
   version: v0.61.0
 api_directory_checksum: e3ea3d54f0e513853e3b8fd85fa0c386fb01459b
 api_version: v1alpha1
-aws_sdk_go_version: v1.32.6
+aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: d839a4e49aed6b50122aaaca5e3944674564691c
+  file_checksum: 16c488c4388df05d2ca72ff65d3edebf482d9fd4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -4,10 +4,12 @@ ignore:
       - CreateResourceShareOutput.ClientToken
       - CreatePermissionInput.ClientToken
       - CreatePermissionOutput.ClientToken
+      - GetResourceSharesInput.Name
   resource_names:
       - PermissionVersion
 resources:
   ResourceShare:
+    is_arn_primary_key: true
     exceptions:
       terminal_codes:
         - MalformedArnException
@@ -30,6 +32,8 @@ resources:
         code: compareTags(delta, a, b)
       sdk_update_pre_build_request:
         template_path: hooks/resource_share/sdk_update_pre_build_request.go.tpl
+      sdk_read_many_pre_build_request:
+        template_path: hooks/resource_share/sdk_read_many_pre_build_request.go.tpl
       sdk_read_many_post_build_request:
         template_path: hooks/resource_share/sdk_find_read_many_post_build_request.go.tpl
       sdk_read_many_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -4,10 +4,12 @@ ignore:
       - CreateResourceShareOutput.ClientToken
       - CreatePermissionInput.ClientToken
       - CreatePermissionOutput.ClientToken
+      - GetResourceSharesInput.Name
   resource_names:
       - PermissionVersion
 resources:
   ResourceShare:
+    is_arn_primary_key: true
     exceptions:
       terminal_codes:
         - MalformedArnException
@@ -30,6 +32,8 @@ resources:
         code: compareTags(delta, a, b)
       sdk_update_pre_build_request:
         template_path: hooks/resource_share/sdk_update_pre_build_request.go.tpl
+      sdk_read_many_pre_build_request:
+        template_path: hooks/resource_share/sdk_read_many_pre_build_request.go.tpl
       sdk_read_many_post_build_request:
         template_path: hooks/resource_share/sdk_find_read_many_post_build_request.go.tpl
       sdk_read_many_post_set_output:

--- a/pkg/resource/resource_share/resource.go
+++ b/pkg/resource/resource_share/resource.go
@@ -87,21 +87,26 @@ func (r *resource) SetStatus(desired acktypes.AWSResource) {
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
-	if identifier.NameOrID == "" {
-		return ackerrors.MissingNameIdentifier
+	if r.ko.Status.ACKResourceMetadata == nil {
+		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	r.ko.Spec.Name = &identifier.NameOrID
+	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
 
 	return nil
 }
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	f1, ok := fields["name"]
+	resourceARN, ok := fields["arn"]
 	if !ok {
-		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))
 	}
-	r.ko.Spec.Name = &f1
+
+	if r.ko.Status.ACKResourceMetadata == nil {
+		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	arn := ackv1alpha1.AWSResourceName(resourceARN)
+	r.ko.Status.ACKResourceMetadata.ARN = &arn
 
 	return nil
 }

--- a/pkg/resource/resource_share/sdk.go
+++ b/pkg/resource/resource_share/sdk.go
@@ -63,6 +63,9 @@ func (rm *resourceManager) sdkFind(
 	defer func() {
 		exit(err)
 	}()
+	if r.ko.Status.ACKResourceMetadata == nil || r.ko.Status.ACKResourceMetadata.ARN == nil {
+		return nil, ackerr.NotFound
+	}
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.
@@ -79,6 +82,10 @@ func (rm *resourceManager) sdkFind(
 	input.ResourceOwner = svcsdktypes.ResourceOwnerSelf
 	if r.ko.Status.OwningAccountID != nil && *r.ko.Status.OwningAccountID != string(rm.awsAccountID) {
 		input.ResourceOwner = svcsdktypes.ResourceOwnerOtherAccounts
+	}
+	// only gets the ResourceShare identified by this ARN
+	if r.ko.Status.ACKResourceMetadata != nil && r.ko.Status.ACKResourceMetadata.ARN != nil {
+		input.ResourceShareArns = []string{string(*r.ko.Status.ACKResourceMetadata.ARN)}
 	}
 	var resp *svcsdk.GetResourceSharesOutput
 	resp, err = rm.sdkapi.GetResourceShares(ctx, input)
@@ -185,8 +192,7 @@ func (rm *resourceManager) sdkFind(
 func (rm *resourceManager) requiredFieldsMissingFromReadManyInput(
 	r *resource,
 ) bool {
-	return r.ko.Spec.Name == nil
-
+	return false
 }
 
 // newListRequestPayload returns SDK-specific struct for the HTTP request
@@ -195,10 +201,6 @@ func (rm *resourceManager) newListRequestPayload(
 	r *resource,
 ) (*svcsdk.GetResourceSharesInput, error) {
 	res := &svcsdk.GetResourceSharesInput{}
-
-	if r.ko.Spec.Name != nil {
-		res.Name = r.ko.Spec.Name
-	}
 
 	return res, nil
 }

--- a/templates/hooks/resource_share/sdk_find_read_many_post_build_request.go.tpl
+++ b/templates/hooks/resource_share/sdk_find_read_many_post_build_request.go.tpl
@@ -4,3 +4,7 @@
 	if r.ko.Status.OwningAccountID != nil && *r.ko.Status.OwningAccountID != string(rm.awsAccountID) {
 		input.ResourceOwner = svcsdktypes.ResourceOwnerOtherAccounts
 	}
+    // only gets the ResourceShare identified by this ARN
+    if r.ko.Status.ACKResourceMetadata != nil && r.ko.Status.ACKResourceMetadata.ARN != nil {
+        input.ResourceShareArns = []string{string(*r.ko.Status.ACKResourceMetadata.ARN)}
+    }

--- a/templates/hooks/resource_share/sdk_read_many_pre_build_request.go.tpl
+++ b/templates/hooks/resource_share/sdk_read_many_pre_build_request.go.tpl
@@ -1,0 +1,3 @@
+    if r.ko.Status.ACKResourceMetadata == nil || r.ko.Status.ACKResourceMetadata.ARN == nil {
+		return nil, ackerr.NotFound
+	}


### PR DESCRIPTION
We're using ACK team based CARM, where a single namespace is mapped to a team. Each team is creating a ResourceShare CR with the same name in their VPC, but the RAM controller is querying for ResourceShares via the .spec.Name key. This makes it such that all of the ResourceShare objects in all namespaces end up getting the same ARN, and the resources shared get overwritten.

We should be matching on ARN and not on the name, since thats a unique identifier for the share. If the ID of the share was available as a standalone field (similar to VPC ID) then things would have been easier.